### PR TITLE
feat: 메인 헤더 레이아웃 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,12 @@
-import {useState} from 'react'
-import reactLogo from './assets/react.svg'
+import {Route, Routes} from "react-router-dom";
+import {MainPage} from "./pages/MainPage";
 
 function App() {
-    const [count, setCount] = useState(0)
-
     return (
         <div className="App">
-
+            <Routes>
+                <Route path="/" element={<MainPage/>}/>
+            </Routes>
         </div>
     )
 }

--- a/frontend/src/assets/hamburger.svg
+++ b/frontend/src/assets/hamburger.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 16H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 8H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 24H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/user.svg
+++ b/frontend/src/assets/user.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 16H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 8H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 24H28" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/MainHeader.tsx
+++ b/frontend/src/components/MainHeader.tsx
@@ -1,0 +1,23 @@
+import {MainHeaderContainer, AnchorLogo, GreenMark, MenuContainer} from "../styles/MainHeader.style";
+
+export const MainHeader = () => {
+  //isloggedin 필요
+  return (
+    <MainHeaderContainer>
+      <AnchorLogo>
+        Camper<GreenMark>Rank</GreenMark>
+      </AnchorLogo>
+      <nav>
+        <ul>
+          <li><a href="/html/intro">문제 리스트</a></li>
+          <li><a href="/css/intro">랭킹</a></li>
+          <li><a href="/javascript/intro">대회</a></li>
+        </ul>
+      </nav>
+      <MenuContainer>
+        <button type={"button"}>{"회원가입"}</button>
+        <button type={"button"}>{"로그인"}</button>
+      </MenuContainer>
+    </MainHeaderContainer>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App'
 
 import {BrowserRouter} from "react-router-dom";
 import {RecoilRoot} from 'recoil';
-import {GlobalStyle} from "@src/styles/GlobalStyle";
+import {GlobalStyle} from "./styles/GlobalStyle";
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,0 +1,10 @@
+import {MainHeader} from "../components/MainHeader";
+
+export const MainPage = ({}) => {
+
+    return (
+        <>
+            <MainHeader/>
+        </>
+    );
+}

--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -1,4 +1,9 @@
 import {createGlobalStyle} from "styled-components";
 
 export const GlobalStyle = createGlobalStyle`
+  
+  * {
+    font-family: Noto Sans KR,serif;
+    list-style: none;
+  }
 `;

--- a/frontend/src/styles/MainHeader.style.tsx
+++ b/frontend/src/styles/MainHeader.style.tsx
@@ -1,0 +1,56 @@
+import styled from "styled-components";
+
+export const MainHeaderContainer = styled.div`
+  box-sizing: border-box;
+  width: 100vw;
+  padding: 0 96px;
+  height: 120px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  nav {
+    margin-right: 128px;
+    ul {
+      justify-content: space-between;
+      align-items: center;
+
+      li {
+        float: left;
+        margin-left: 96px;
+
+        a {
+          text-decoration: none;
+          font-weight: 600;
+          font-size: 24px;
+          color: black;
+        }
+      }
+    }
+  }
+`;
+
+export const AnchorLogo = styled.a`
+  font-weight: 700;
+  font-size: 32px;
+`;
+
+export const GreenMark = styled.mark`
+  color: #1F7A41;
+  background: none;
+`;
+
+export const MenuContainer = styled.div`
+  margin-bottom: 64px;
+  button{
+    cursor: pointer;
+    font-family: Noto Sans KR,serif;
+    font-weight: 500;
+    font-size: 12px;
+    border: none;
+    background: none;
+    &:nth-child(1){
+      border-right: solid 1px silver;
+    };
+  }
+`;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,12 +19,12 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
-    "paths": {
-      "@src/*": [
-        "src/*"
-      ]
-    }
+//    "baseUrl": ".",
+//    "paths": {
+//      "@src/*": [
+//        "src/*"
+//      ]
+//    }
   },
   "include": [
     "src"


### PR DESCRIPTION
## 메인 헤더 레이아웃 구현

### PR 생성날짜

* 2022/11/15

### 작업내용
메인 헤더의 레이아웃을 구현하였습니다.

### 주요 변경점
* 메인 헤더 컴포넌트 생성
* 메인 페이지 컴포넌트 생성
* 버그로 인한 tsconfig 절대 경로 설정 주석처리(조치 필요)
