### PR TITLE
feat: 언어 변경 시 코드 저장

### DIFF
--- a/frontend/src/components/Problem/Content.tsx
+++ b/frontend/src/components/Problem/Content.tsx
@@ -16,7 +16,7 @@ const ContentWrapper = styled.div`
 
 const Level = styled.div`
   position: absolute;
-  top: -1rem;
+  top: -0.7rem;
   left: 0;
   font-weight: bold;
   font-size: 1rem;

--- a/frontend/src/components/Problem/LanguageSelector.tsx
+++ b/frontend/src/components/Problem/LanguageSelector.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
-import { editorState } from '../../recoils';
+import { editorState, socketState } from '../../recoils';
 import { useRecoilState } from 'recoil';
 import { SelectButton } from '../../assets/icons';
+import { useParams } from 'react-router-dom';
 
 type SelectorProp = {
   onClickModalElement: (str: string) => void;
@@ -86,8 +87,12 @@ const Modal = ({ onClickElement, onClickModalElement }: ModalProp) => {
 const LanguageSelector = ({ onClickModalElement }: SelectorProp) => {
   const [editor, setEditor] = useRecoilState(editorState);
   const [open, setOpen] = useState(false);
+  const [socket] = useRecoilState(socketState);
   const selectorRef = useRef<HTMLDivElement>(null);
-  const { language } = editor;
+  const { version } = useParams();
+  const [isMultiVersion] = useState(version === 'multi');
+  const { roomNumber } = isMultiVersion ? useParams() : { roomNumber: null };
+  const [language, setLanguage] = useState(editor.language);
   const handleClickOutside = ({ target }: any) => {
     if (!selectorRef.current || !selectorRef.current.contains(target)) {
       setOpen(false);
@@ -97,8 +102,39 @@ const LanguageSelector = ({ onClickModalElement }: SelectorProp) => {
   const handleClickWrapper = () => setOpen(!open);
 
   const handleModalElement = (language: string) => {
+    if (socket) {
+      socket.emit(
+        'change-language',
+        roomNumber,
+        JSON.stringify(editor),
+        language,
+      );
+    }
     setEditor({ ...editor, language });
   };
+
+  useEffect(() => {
+    setLanguage(editor.language);
+  }, [editor]);
+
+  const saveCode = (code: string, language: string) => {
+    localStorage.setItem(language, code);
+  };
+
+  const changeLanguageCallback = (code: string, lang: string) => {
+    if (!code) return;
+    const { text, language } = JSON.parse(code);
+    saveCode(text, language);
+    setEditor({ ...editor, language: lang });
+  };
+
+  useEffect(() => {
+    if (!socket) return;
+    socket.on('change-language', changeLanguageCallback);
+    return () => {
+      socket.off('change-language', changeLanguageCallback);
+    };
+  }, [socket]);
 
   useEffect(() => {
     window.addEventListener('click', handleClickOutside);

--- a/frontend/src/components/Problem/Video.tsx
+++ b/frontend/src/components/Problem/Video.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import io, { Socket } from 'socket.io-client';
 import { Peer } from 'peerjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
+import { socketState } from '../../recoils';
 
 const VideoContainer = styled.div`
   margin-top: 1rem;
@@ -94,7 +96,7 @@ export const Video = () => {
   const navigate = useNavigate();
 
   const [myPeer, setMyPeer] = useState<Peer>();
-  const [socket, setSocket] = useState<Socket>();
+  const [socket, setSocket] = useRecoilState(socketState);
 
   useEffect(() => {
     navigator.mediaDevices.getUserMedia(Constraints).then((mediaStream) => {

--- a/frontend/src/pages/Problem.tsx
+++ b/frontend/src/pages/Problem.tsx
@@ -249,18 +249,6 @@ const Problem = () => {
     navigate('/');
   }, [isMultiVersion, roomNumber]);
 
-  const handleChangeEditorLanguage = (language: string) => {
-    if (eView) {
-      let insertCode;
-      if (language === '' || language === 'JavaScript' || language === 'Python')
-        insertCode = defaultCode[language];
-      const transaction = eView.state.update({
-        changes: { from: 0, to: eView.state.doc.length, insert: insertCode },
-      });
-      eView.dispatch(transaction);
-    }
-  };
-
   useEffect(() => {
     fetch(`${URL}/problem/${id}`)
       .then((res) => res.json())
@@ -306,9 +294,6 @@ const Problem = () => {
       });
 
     const languageExtension = languageCompartment.of(langs['JavaScript']);
-    // const highlightThemeExtension = highlightThemeCompartment.of(
-    //   highlightThemeExtensions['dark'],
-    // );
 
     const extensions = [
       basicSetup,
@@ -380,6 +365,51 @@ const Problem = () => {
     });
   }, []);
 
+  useEffect(() => {
+    return () => {
+      localStorage.removeItem('JavaScript');
+      localStorage.removeItem('Python');
+    };
+  }, []);
+
+  const saveCode = (code: string, language: string) => {
+    localStorage.setItem(language, code);
+  };
+
+  const getSavedCode = (language: string) => {
+    return localStorage.getItem(language);
+  };
+
+  const handleChangeEditorLanguage = (language: string) => {
+    if (eView) {
+      let insertCode;
+      const { text: priorText, language: priorLanguage } = code;
+      saveCode(priorText, priorLanguage);
+      if (language === '' || language === 'JavaScript' || language === 'Python')
+        insertCode = defaultCode[language];
+      const savedCode = getSavedCode(language);
+      if (savedCode) insertCode = savedCode;
+      const transaction = eView.state.update({
+        changes: { from: 0, to: eView.state.doc.length, insert: insertCode },
+      });
+      eView.dispatch(transaction);
+    }
+  };
+
+  const handleClickClearButton = () => {
+    if (eView) {
+      let insertCode;
+      const { text: priorText, language: priorLanguage } = code;
+      saveCode(priorText, priorLanguage);
+      if (language === '' || language === 'JavaScript' || language === 'Python')
+        insertCode = defaultCode[language];
+      const transaction = eView.state.update({
+        changes: { from: 0, to: eView.state.doc.length, insert: insertCode },
+      });
+      eView.dispatch(transaction);
+    }
+  };
+
   const handleSize = () => {
     const PX = +REM.replace('px', '');
     if (editorRef.current)
@@ -393,6 +423,7 @@ const Problem = () => {
         window.innerWidth * 0.47,
       )}px`;
   };
+
   const resizeProblemWrapper = (x: number) => {
     if (problemRef.current != null && editorRef.current != null) {
       const problemRefWidth = +problemRef.current.style.width.replace('px', '');
@@ -418,6 +449,7 @@ const Problem = () => {
       )}px`;
     }
   };
+
   const resizeEditorWrapper = (y: number) => {
     if (editorRef.current != null) {
       const PX = +REM.replace('px', '');
@@ -489,7 +521,7 @@ const Problem = () => {
             <Result></Result>
           </ResultWrapper>
           <ButtonsWrapper>
-            <ProblemButtons onClickClearBtn={handleChangeEditorLanguage} />
+            <ProblemButtons onClickClearBtn={handleClickClearButton} />
           </ButtonsWrapper>
         </SolvingWrapper>
       </MainWrapper>

--- a/frontend/src/pages/Problem.tsx
+++ b/frontend/src/pages/Problem.tsx
@@ -366,10 +366,8 @@ const Problem = () => {
   }, []);
 
   useEffect(() => {
-    return () => {
-      localStorage.removeItem('JavaScript');
-      localStorage.removeItem('Python');
-    };
+    localStorage.removeItem('JavaScript');
+    localStorage.removeItem('Python');
   }, []);
 
   const saveCode = (code: string, language: string) => {

--- a/frontend/src/recoils/index.ts
+++ b/frontend/src/recoils/index.ts
@@ -2,4 +2,5 @@ import { filterState } from './filterState';
 import { editorState } from './editorState';
 import { userState } from './userState';
 import { gradingState } from './gradingState';
-export { filterState, editorState, userState, gradingState };
+import { socketState } from './socketState';
+export { filterState, editorState, userState, gradingState, socketState };

--- a/frontend/src/recoils/socketState.tsx
+++ b/frontend/src/recoils/socketState.tsx
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+import { Socket } from 'socket.io-client';
+
+export const socketState = atom<Socket | undefined>({
+  key: 'socketState',
+  default: undefined,
+  dangerouslyAllowMutability: true,
+});

--- a/socket/src/app.ts
+++ b/socket/src/app.ts
@@ -43,10 +43,10 @@ io.on('connection', (socket) => {
     });
   });
 
-  socket.on('change-webrtc', (roomId, userId) => {
-    logging('change userId: ', userId);
+  socket.on('change-language', (roomId, code) => {
     logging('roomId: ', roomId);
-    socket.to(roomId).emit('change-webrtc', userId);
+    logging('code: ', code);
+    socket.to(roomId).emit('change-language', code);
   });
 });
 


### PR DESCRIPTION
## feat: 언어 변경 시 코드 저장

### PR 생성날짜

* 2022/12/13

### 작업내용
- 혼자 풀기, 같이 풀기 언어 변경 시 코드 localstorage에 저장.

### 주요 변경점
혼자 풀기 -> 언어 변경 클릭 시 localstorage에 저장
같이 풀기 -> 언어 변경 클릭 -> socket 이용하여 해당 방 피어들에게 코드 및 언어 전달하여, 해당 코드+언어 저장 및 언어 변경

