### PR TITLE
feat: js, css만 압축시키고, MTU 크기 고려해서 1400바이트 이상만 압축하도록 설정

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,13 @@ import { compression } from 'vite-plugin-compression2';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [svgr(), react(), tsconfigPaths(), compression()],
+  plugins: [
+    svgr(),
+    react(),
+    tsconfigPaths(),
+    compression({
+      include: [/\.(js)$/, /\.(css)$/],
+      threshold: 1400,
+    }),
+  ],
 });


### PR DESCRIPTION
## PR 타이틀
vite 프로젝트 빌드 시 압축 설정
### PR 생성날짜

* 2022/12/15

### 작업내용
빌드 시 압축에 확장자 및 threshold 설정

### 주요 변경점
1400 byte 이상만 압축하도록 (MTU 고려하여)
이미지는 압축안하도록 설정